### PR TITLE
Add support for ISO-8859-1 characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "addresscompiler",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "homepage": "https://github.com/closeio/addresscompiler",
     "description": "Compile rfc2822 address fields",
     "author": "Phil Freo <phil@philfreo.com> (http://philfreo.com/)",

--- a/src/addresscompiler.js
+++ b/src/addresscompiler.js
@@ -64,10 +64,8 @@
      * @returns {String} Mime word encoded string if needed
      */
     addresscompiler._encodeAddressName = function(name) {
-        if (!/^[\w ']*$/.test(name)) {
-            if (/^[\x20-\x7e]*$/.test(name)) {
-                return '"' + name.replace(/([\\"])/g, '\\$1') + '"';
-            }
+        if (!/^[\w ']*$/.test(name) && /^[\x00-\x7F\xA0-\xFF]*$/.test(name)) {
+            return '"' + name.replace(/([\\"])/g, '\\$1') + '"';
         }
         return name;
     };

--- a/test/addresscompiler-unit.js
+++ b/test/addresscompiler-unit.js
@@ -125,6 +125,51 @@
                 expect(addresscompiler.compile(input)).to.deep.equal(expected);
             });
 
+            it("should handle comma in name correctly", function() {
+                var input = [{
+                    name: 'My name, My Title',
+                    address: "a@a.com"
+                }];
+                var expected = '"My name, My Title" <a@a.com>';
+                expect(addresscompiler.compile(input)).to.deep.equal(expected);
+            });
+
+            it("should handle semicolon in name correctly", function() {
+                var input = [{
+                    name: 'My name; My Title',
+                    address: "a@a.com"
+                }];
+                var expected = '"My name; My Title" <a@a.com>';
+                expect(addresscompiler.compile(input)).to.deep.equal(expected);
+            });
+
+            it("should handle special charactes in name correctly", function() {
+                var input = [{
+                    name: 'Günther Steiner',
+                    address: "a@a.com"
+                }];
+                var expected = '"Günther Steiner" <a@a.com>';
+                expect(addresscompiler.compile(input)).to.deep.equal(expected);
+            });
+
+            it("should handle special charactes with comma in name correctly", function() {
+                var input = [{
+                    name: 'Günther Steiner, Geschäftsführender',
+                    address: "a@a.com"
+                }];
+                var expected = '"Günther Steiner, Geschäftsführender" <a@a.com>';
+                expect(addresscompiler.compile(input)).to.deep.equal(expected);
+            });
+
+            it("should handle special charactes with semicolon in name correctly", function() {
+                var input = [{
+                    name: 'Günther Steiner; Geschäftsführender',
+                    address: "a@a.com"
+                }];
+                var expected = '"Günther Steiner; Geschäftsführender" <a@a.com>';
+                expect(addresscompiler.compile(input)).to.deep.equal(expected);
+            });
+
         });
     });
 }));


### PR DESCRIPTION
While investigating https://github.com/closeio/closeio/issues/31049 we noticed that our FE was failing to correctly send the email address as per `RFC822` when we had special characters in the sender's name.

My main question would be why we have this ASCII/characters check in the first place? I know it's been 8 years but do you remember @philfreo? Why don't we just wrap in `"` all names where we find a special character? 

This add support for [ISO-8859](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) and [Windows-1252](https://en.wikipedia.org/wiki/Windows-1252) list of characters instead of the 128 ASCII we had before.

All tests are passing
<img width="575" alt="Screen Shot 2022-12-02 at 14 40 19" src="https://user-images.githubusercontent.com/13576166/205308807-619f240a-0d1a-445f-b9e8-7c777609448b.png">

